### PR TITLE
iOS 오타 수정

### DIFF
--- a/src/content/docs/ios/01-keyword.md
+++ b/src/content/docs/ios/01-keyword.md
@@ -54,7 +54,7 @@ title: 공부 키워드
     - 등등
 - 비동기 처리
     - GCD
-    - GCDRxSwift
+    - RxSwift
     - Combine
     - Swift Concurrency
 - Tuist / XCConfing / 환경변수


### PR DESCRIPTION
`RxSwift` 가 `GCD`와 붙어 `GCDRxSwift`로 되어있어 이를 수정합니다.